### PR TITLE
Add "$prefix/lib64" into library search path.

### DIFF
--- a/bin/make_sandbox_from_installed
+++ b/bin/make_sandbox_from_installed
@@ -93,7 +93,8 @@ for my $prefix (@prefixes) {
         $found_install_db =1;
     }
     if ( glob("$prefix/lib/mysql/libmysqlclient*") 
-       or glob( "$prefix/lib/libmysqlclient*")  ) {
+       or glob( "$prefix/lib/libmysqlclient*")
+       or glob( "$prefix/lib64/libmysqlclient*")  ) {
         $found_libraries =1;
     }
 }


### PR DESCRIPTION
patch for #3 .

  rpm packages for 64bit environment are installing libraries into
  /usr/lib64($prefix/lib64), rpm for 32bit are still using
  /usr/lib($prefix/lib)
