### PR TITLE
Do not remove the 'mysql.sys' user.

### DIFF
--- a/lib/MySQL/Sandbox/Scripts.pm
+++ b/lib/MySQL/Sandbox/Scripts.pm
@@ -1512,7 +1512,7 @@ set password='_DBPASSWORD_';
 delete from tables_priv;
 delete from columns_priv;
 delete from db;
-delete from user where user != 'root';
+delete from user where user not in ('root', 'mysql.sys');
 
 flush privileges;
 


### PR DESCRIPTION
5.7.9 added a new 'mysql.sys' user as the owner of the sys objects, do not remove this.