### PR TITLE
Fix sandbox from separated build tree with debug enabled.

### DIFF
--- a/bin/make_sandbox
+++ b/bin/make_sandbox
@@ -220,6 +220,10 @@ elsif  ( $where_to_install =~ m{^(/.+)/(?:\d+\.)?($prefix_regex\D+(\d+)\.(\d+)\.
         if ($rename_result) {
             die "can't rename $new_dir to $new_name";
         }
+        # in case it is a debug build
+        if (-f "$new_name/bin/mysqld-debug" && ! -f "$new_name/bin/mysqld") {
+            system "cd $new_name/bin && ln -s mysqld-debug mysqld";
+        }
         # some versions of Perl and OS can't perform a rename across file systems
         # Bug #504789
         #rename $new_dir, $new_name

--- a/bin/make_sandbox_from_source
+++ b/bin/make_sandbox_from_source
@@ -139,10 +139,20 @@ sub get_source_version {
     #
 
     my $version;
+    my $version_file;
     if ( -f 'VERSION' )
     {
-        open my $VFH, q{<}, 'VERSION'
-            or die "can't open VERSION\n";
+        $version_file = 'VERSION';
+    }
+    # when build tree differs from source tree
+    elsif ( -f 'VERSION.dep' )
+    {
+        $version_file = 'VERSION.dep';
+    }
+    if ( $version_file )
+    {
+        open my $VFH, q{<}, $version_file
+            or die "can't open $version_file\n";
         while (my $line = <$VFH>)
         {
             if ($line =~ /MYSQL_VERSION_(?:MAJOR|MINOR|PATCH)=(\d+)/)
@@ -160,13 +170,13 @@ sub get_source_version {
         }
         unless ($version =~ /\d+\.\d+\.\d+/)
         {
-            die "could not find a version number in VERSION ($version)\n";
+            die "could not find a version number in $version_file ($version)\n";
         }
         return $version;
     }
     else
     {
-        print "# There is no VERSION file in this directory.\n# Now trying with Makefile\n" if $MySQL::Sandbox::DEBUG;
+        print "# There is no VERSION or VERSION.dep file in this directory.\n# Now trying with Makefile\n" if $MySQL::Sandbox::DEBUG;
     }
 
 


### PR DESCRIPTION
make_sandbox_from_source does not understand VERSION.dep from a separated build tree; make_sandbox does not understand mysqld-debug. This patch fix both cases.