### PR TITLE
Add more lib paths for multiarch spec used by Debian / Ubuntu

### DIFF
--- a/bin/make_sandbox_from_installed
+++ b/bin/make_sandbox_from_installed
@@ -94,7 +94,9 @@ for my $prefix (@prefixes) {
     }
     if ( glob("$prefix/lib/mysql/libmysqlclient*") 
        or glob( "$prefix/lib/libmysqlclient*")
-       or glob( "$prefix/lib64/libmysqlclient*")  ) {
+       or glob( "$prefix/lib64/libmysqlclient*")
+       or glob( "$prefix/lib/i386-linux-gnu/libmysqlclient*")
+       or glob( "$prefix/lib/x86_64-linux-gnu/libmysqlclient*")  ) {
         $found_libraries =1;
     }
 }


### PR DESCRIPTION
Debian and Ubuntu follow a new multiarch spec described at https://wiki.ubuntu.com/MultiarchSpec

This pull request adds new paths to locate the libmysqlclient*.so file which should now allow using mysql-sandbox on Debian Jessie.