### PR TITLE
Adding argument checks for change_ports script.

### DIFF
--- a/lib/MySQL/Sandbox/Scripts.pm
+++ b/lib/MySQL/Sandbox/Scripts.pm
@@ -1993,10 +1993,23 @@ OLD_PORT=_SERVERPORT_
 
 if [ "$1" = "" ]
 then
-    echo "new port required"
+    echo "New port required as argument."
     exit
 else
-    NEW_PORT=$1
+    ONLY_DIGITS_REGEX="^[[:digit:]]+$"
+    if [[ $1 =~ ${ONLY_DIGITS_REGEX} ]]
+    then
+        if [[ $1 -ge 1 ]] && [[ $1 -le 65535 ]]
+        then
+            NEW_PORT=$1
+        else
+            echo "New port must be a valid port number in the 1-65535 range."
+            exit
+        fi
+    else
+        echo "New port must contain only digits (unsigned integer)."
+        exit
+    fi
 fi
 
 if [ $OLD_PORT = $NEW_PORT ]


### PR DESCRIPTION
The script now checks if the argument passed as port is numeric-only, and in a valid port range. Feel free to change any of the outputted messages :)

Ports 1-1024 are allowed, but it's easy to change that if it's not wanted.

It may also be nice to add a warning if the port chosen is currently used, but I'm not sure how compatibility between OSs is handled yet, so I'm leaving that as future work. Let me know if you have comments on it, and I'll gladly work on it.