### PR TITLE
Add 7.x versions for MySQL Cluster

### DIFF
--- a/lib/MySQL/Sandbox.pm
+++ b/lib/MySQL/Sandbox.pm
@@ -82,7 +82,7 @@ BEGIN {
 }
 
 my @supported_versions = qw( 3.23 4.0 4.1 5.0 5.1 5.2 5.3 5.4 
-    5.5 5.6 5.7 6.0 8.0 10.0 10.1 10.2 10.3 );
+    5.5 5.6 5.7 6.0 7.0 7.1 7.2 7.3 7.4 7.5 7.6 8.0 10.0 10.1 10.2 10.3 );
 
 our $sandbox_options_file    = "my.sandbox.cnf";
 # our $sandbox_current_options = "current_options.conf";


### PR DESCRIPTION
I know dbdeployer is taking over eventually..