### PR TITLE
Add support for MariaDB 10.4+

### DIFF
--- a/lib/MySQL/Sandbox.pm
+++ b/lib/MySQL/Sandbox.pm
@@ -82,7 +82,7 @@ BEGIN {
 }
 
 my @supported_versions = qw( 3.23 4.0 4.1 5.0 5.1 5.2 5.3 5.4 
-    5.5 5.6 5.7 6.0 7.0 7.1 7.2 7.3 7.4 7.5 7.6 8.0 10.0 10.1 10.2 10.3 );
+    5.5 5.6 5.7 6.0 7.0 7.1 7.2 7.3 7.4 7.5 7.6 8.0 10.0 10.1 10.2 10.3 10.4 );
 
 our $sandbox_options_file    = "my.sandbox.cnf";
 # our $sandbox_current_options = "current_options.conf";

--- a/lib/MySQL/Sandbox/Scripts.pm
+++ b/lib/MySQL/Sandbox/Scripts.pm
@@ -1861,6 +1861,11 @@ if [ "$MAJOR" == "8" ]
 then
     cp $SBDIR/grants_5_7_6.mysql $SBDIR/grants.mysql
 fi
+if [ "$MAJOR" == "10" -a "$MINOR" -ge 4 ]
+then
+    # password column since MariaDB 10.4.0 is empty and hashed password itself is stored in authentication_string column
+    sed "s/delete from user where password='';/delete from user where password='' and (authentication_string='' or plugin!='mysql_native_password');/" -i $SBDIR/grants.mysql
+fi
 # END UGLY WORKAROUND
 VERBOSE_SQL=''
 [ -n "$SBDEBUG" ] && VERBOSE_SQL=-v


### PR DESCRIPTION
In MariaDB 10.4 is password column in user table always empty. Real
password hashes are stored in authentication_string column.

Therefore patch grants.mysql script to not only match password=''.

And add MariaDB 10.4 into supported versions whitelist.